### PR TITLE
fixed navigation links in the header

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,21 +26,21 @@
     </header>
     <figure class="hero"></figure>
     <main class="content">
-        <section class="search-engine-optimization">
+        <section id="search-engine-optimization" class="search-engine-optimization">
             <img src="./assets/images/search-engine-optimization.jpg" class="float-left" />
             <h2>Search Engine Optimization</h2>
             <p>
                 The dominance of mobile internet use means that users are searching for the right business as they travel, shop, or sit on their couch at home. Search Engine Optimization (SEO) allows you to increase your visibility and find the right customers for your business.
             </p>
         </section>
-        <section class="online-reputation-management">
+        <section id="online-reputation-management" class="online-reputation-management">
             <img src="./assets/images/online-reputation-management.jpg" class="float-right" />
             <h2>Online Reputation Management</h2>
             <p>
                 The web is full of opinions, and some of these can be negative. Social media allows anyone with an internet connection to say whatever they want about your business. Online Reputation Management gives you the control over what potential customers see when they search for your business.
             </p>
         </section>
-        <section class="social-media-marketing">
+        <section id="social-media-marketing" class="social-media-marketing">
             <img src="./assets/images/social-media-marketing.jpg" class="float-left" />
             <h2>Social Media Marketing</h2>
             <p>


### PR DESCRIPTION
I discovered the section ids I removed in the previous PR were there for a reason: they are linked to the clickable links in the navigation header. this has been fixed and the links are now functioning as intended